### PR TITLE
Don't joinArrays if joinArrays is false

### DIFF
--- a/lib/observable-search-params.ts
+++ b/lib/observable-search-params.ts
@@ -57,7 +57,7 @@ export class ObservableSearchParams {
 
     Array.from(new URLSearchParams(search)).forEach(([param, value]) => {
       if (skipEmpty && !value) return;
-      const values: string[] = joinArraysWith ? value.split(joinArraysWith) : [value];
+      const values: string[] = joinArrays ? value.split(joinArraysWith) : [value];
       params[param] ??= [];
       params[param].push(...values);
     });


### PR DESCRIPTION
This fixes a bug that I discovered while working on https://github.com/lensapp/lens/issues/4326