### PR TITLE
Fix README.md about external history instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,11 @@ import { autorun, reaction, comparer } from "mobx"
 import { createBrowserHistory } from "history";
 import { createObservableHistory } from "mobx-observable-history"
 
-const history = createBrowserHistory();
-const navigation = createObservableHistory(history);
+// Comaptible with `react-router` through supplying external `history` instance, tested with history@^4.10.1
+// const history = createBrowserHistory();
+// const navigation = createObservableHistory(history);
+
+const navigation = createObservableHistory();
 
 // Reacting to any location change
 autorun(() => {

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ to use reactivity everywhere.
 
 ```javascript
 import { autorun, reaction, comparer } from "mobx"
-import { createBrowserHistory } from "history";
 import { createObservableHistory } from "mobx-observable-history"
 
 // Comaptible with `react-router` through supplying external `history` instance, tested with history@^4.10.1
+// import { createBrowserHistory } from "history";
 // const history = createBrowserHistory();
 // const navigation = createObservableHistory(history);
 


### PR DESCRIPTION
The latest version of `history` doesn't seem to be compatible and the readme confused me to install it myself and it ended up crashing on navigation.